### PR TITLE
게임 플레이어의 이름 입력 및 수정 기능을 구현합니다.

### DIFF
--- a/NumberGame.xcodeproj/project.pbxproj
+++ b/NumberGame.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		603486E82591009C0060EF0C /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603486E72591009C0060EF0C /* Extensions.swift */; };
 		603486F3259106840060EF0C /* UpAndDownGameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603486F2259106840060EF0C /* UpAndDownGameViewController.swift */; };
 		606416F525A6EBE9004ED168 /* InputNumberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606416F425A6EBE9004ED168 /* InputNumberViewController.swift */; };
 		606416F925A6ED9C004ED168 /* Array+Chunked.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606416F825A6ED9C004ED168 /* Array+Chunked.swift */; };
@@ -21,6 +20,7 @@
 		FF03A30025BDB07100F87B82 /* CoreDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF03A2FF25BDB07100F87B82 /* CoreDataService.swift */; };
 		FF83C26A25AA3E920020E7EC /* UIColor+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF83C26925AA3E920020E7EC /* UIColor+Init.swift */; };
 		FF83C27225AB62DB0020E7EC /* NumberGameInputLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF83C27125AB62DB0020E7EC /* NumberGameInputLog.swift */; };
+		FFA9354D261CB3D600CE1EAD /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA9354C261CB3D600CE1EAD /* UIViewController+Alert.swift */; };
 		FFE267F125B5D02E0099549A /* ScoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE267F025B5D02E0099549A /* ScoreViewController.swift */; };
 		FFE267F525B5D1020099549A /* ScoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE267F425B5D1020099549A /* ScoreCell.swift */; };
 		FFE267F925B5D5EC0099549A /* ScoreLogsDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = FFE267F725B5D5EC0099549A /* ScoreLogsDataModel.xcdatamodeld */; };
@@ -32,7 +32,6 @@
 
 /* Begin PBXFileReference section */
 		0BE6DD22B5D21258449E3469 /* Pods-NumberGame.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NumberGame.release.xcconfig"; path = "Target Support Files/Pods-NumberGame/Pods-NumberGame.release.xcconfig"; sourceTree = "<group>"; };
-		603486E72591009C0060EF0C /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		603486F2259106840060EF0C /* UpAndDownGameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpAndDownGameViewController.swift; sourceTree = "<group>"; };
 		606416F425A6EBE9004ED168 /* InputNumberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputNumberViewController.swift; sourceTree = "<group>"; };
 		606416F825A6ED9C004ED168 /* Array+Chunked.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Chunked.swift"; sourceTree = "<group>"; };
@@ -50,6 +49,7 @@
 		FF03A2FF25BDB07100F87B82 /* CoreDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataService.swift; sourceTree = "<group>"; };
 		FF83C26925AA3E920020E7EC /* UIColor+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Init.swift"; sourceTree = "<group>"; };
 		FF83C27125AB62DB0020E7EC /* NumberGameInputLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberGameInputLog.swift; sourceTree = "<group>"; };
+		FFA9354C261CB3D600CE1EAD /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		FFE267F025B5D02E0099549A /* ScoreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreViewController.swift; sourceTree = "<group>"; };
 		FFE267F425B5D1020099549A /* ScoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoreCell.swift; sourceTree = "<group>"; };
 		FFE267F825B5D5EC0099549A /* ScoreLogsDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = ScoreLogsDataModel.xcdatamodel; sourceTree = "<group>"; };
@@ -84,7 +84,7 @@
 				FF03A2FE25BDB04E00F87B82 /* CoreData */,
 				FFE2680B25B687AC0099549A /* String */,
 				606416F725A6ED90004ED168 /* Array */,
-				603486E72591009C0060EF0C /* Extensions.swift */,
+				FFA9354A261CB3BB00CE1EAD /* UIViewController */,
 				609257A025A8F15000D407B0 /* UIImage */,
 			);
 			path = Utilities;
@@ -226,6 +226,14 @@
 				FF03A2FF25BDB07100F87B82 /* CoreDataService.swift */,
 			);
 			path = CoreData;
+			sourceTree = "<group>";
+		};
+		FFA9354A261CB3BB00CE1EAD /* UIViewController */ = {
+			isa = PBXGroup;
+			children = (
+				FFA9354C261CB3D600CE1EAD /* UIViewController+Alert.swift */,
+			);
+			path = UIViewController;
 			sourceTree = "<group>";
 		};
 		FFE267EF25B5CFF90099549A /* ScoreViewController */ = {
@@ -393,7 +401,6 @@
 			files = (
 				60DCA7AE258B4E94009BD9B4 /* AppDelegate.swift in Sources */,
 				606416F925A6ED9C004ED168 /* Array+Chunked.swift in Sources */,
-				603486E82591009C0060EF0C /* Extensions.swift in Sources */,
 				FF83C26A25AA3E920020E7EC /* UIColor+Init.swift in Sources */,
 				FFE267F525B5D1020099549A /* ScoreCell.swift in Sources */,
 				60D7B6952590FFE20078E884 /* GameCell.swift in Sources */,
@@ -408,6 +415,7 @@
 				60DCA7B0258B4E94009BD9B4 /* SceneDelegate.swift in Sources */,
 				609257A225A8F16600D407B0 /* UIImageFromUIColor.swift in Sources */,
 				603486F3259106840060EF0C /* UpAndDownGameViewController.swift in Sources */,
+				FFA9354D261CB3D600CE1EAD /* UIViewController+Alert.swift in Sources */,
 				FF83C27225AB62DB0020E7EC /* NumberGameInputLog.swift in Sources */,
 				FFEF4EAD25B206C7006B4F03 /* LatelyResultCell.swift in Sources */,
 			);

--- a/NumberGame/Resources/ScoreLogsDataModel.xcdatamodeld/ScoreLogsDataModel.xcdatamodel/contents
+++ b/NumberGame/Resources/ScoreLogsDataModel.xcdatamodeld/ScoreLogsDataModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17192" systemVersion="20B29" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20D91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Log" representedClassName="LogMO" syncable="YES" codeGenerationType="class">
         <attribute name="inputtedNumber" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="result" optional="YES" attributeType="String"/>
@@ -8,10 +8,11 @@
     <entity name="Score" representedClassName="ScoreMO" syncable="YES" codeGenerationType="class">
         <attribute name="date" optional="YES" attributeType="String"/>
         <attribute name="inputCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="playerName" optional="YES" attributeType="String"/>
         <relationship name="logs" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Log" inverseName="score" inverseEntity="Log"/>
     </entity>
     <elements>
         <element name="Log" positionX="-54" positionY="9" width="128" height="74"/>
-        <element name="Score" positionX="-63" positionY="-18" width="128" height="74"/>
+        <element name="Score" positionX="-63" positionY="-18" width="128" height="89"/>
     </elements>
 </model>

--- a/NumberGame/Sources/Features/Logs/LogsViewController.swift
+++ b/NumberGame/Sources/Features/Logs/LogsViewController.swift
@@ -35,7 +35,7 @@ class LogsViewController: UIViewController {
   // MARK: Configuring
 
   private func configureViews() {
-    self.title = self.score.date?.dateTransformToTitle()
+    self.title = self.score.playerName
     self.view.backgroundColor = .systemBackground
     self.configureTableView()
     self.layoutViews()

--- a/NumberGame/Sources/Features/ScoreViewController/ScoreViewController.swift
+++ b/NumberGame/Sources/Features/ScoreViewController/ScoreViewController.swift
@@ -101,8 +101,7 @@ extension ScoreViewController: UITableViewDataSource {
     guard let cell = tableView.dequeueReusableCell(withIdentifier: ReuseIdentifier.scoreCell) as? ScoreCell else {
       return UITableViewCell()
     }
-    cell.set(title: "\(row.date ?? "")의 게임", subTitle: "\(row.inputCount)회 시도")
-
+    cell.set(date: row.date ?? "", count: "\(row.inputCount)회 시도", name: "Player : \(row.playerName ?? "")")
     return cell
   }
 
@@ -128,6 +127,10 @@ extension ScoreViewController: UITableViewDataSource {
     }
 
     return UISwipeActionsConfiguration(actions: [deleteAction, editAction])
+  }
+
+  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    return 56
   }
 }
 

--- a/NumberGame/Sources/Features/ScoreViewController/ScoreViewController.swift
+++ b/NumberGame/Sources/Features/ScoreViewController/ScoreViewController.swift
@@ -106,17 +106,28 @@ extension ScoreViewController: UITableViewDataSource {
     return cell
   }
 
-  func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
-    return .delete
-  }
+  func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+    let score = self.scoreList[indexPath.row]
 
-  func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-    let data = self.scoreList[indexPath.row]
-
-    if self.coreDataService.delete(data.objectID) {
-      self.scoreList.remove(at: indexPath.row)
-      tableView.deleteRows(at: [indexPath], with: .fade)
+    let editAction = UIContextualAction(style: .normal, title: "Edit") { (action, view, success) in
+      self.inputTextAlert(title: "변경할 이름을 입력하세요.", message: nil, isCancel: true) { [weak self] alert in
+        guard let self = self else { return }
+        if self.coreDataService.edit(score.objectID, name: alert.textFields?[0].text ?? "") {
+          tableView.reloadRows(at: [indexPath], with: .automatic)
+        }
+      }
+      success(true)
     }
+
+    let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { [weak self] (action, view, success) in
+      guard let self = self else { return }
+      if self.coreDataService.delete(score.objectID) {
+        self.scoreList.remove(at: indexPath.row)
+        tableView.deleteRows(at: [indexPath], with: .automatic)
+      }
+    }
+
+    return UISwipeActionsConfiguration(actions: [deleteAction, editAction])
   }
 }
 

--- a/NumberGame/Sources/Features/ScoreViewController/View/ScoreCell.swift
+++ b/NumberGame/Sources/Features/ScoreViewController/View/ScoreCell.swift
@@ -6,14 +6,35 @@
 //
 
 import UIKit
+import SnapKit
 
 class ScoreCell: UITableViewCell {
+
+  // MARK: UI
+
+  private let playDate: UILabel = {
+    let label = UILabel()
+    label.font = .systemFont(ofSize: 13)
+    return label
+  }()
+  private let playCount: UILabel = {
+    let label = UILabel()
+    label.font = .systemFont(ofSize: 15)
+    label.textColor = .systemGray2
+    return label
+  }()
+  private let playerName: UILabel = {
+    let label = UILabel()
+    label.font = .systemFont(ofSize: 17, weight: .bold)
+    return label
+  }()
 
 
   // MARK: Initializing
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-    super.init(style: .value1, reuseIdentifier: reuseIdentifier)
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    self.layout()
     self.configure()
   }
 
@@ -29,8 +50,31 @@ class ScoreCell: UITableViewCell {
     self.accessoryType = .disclosureIndicator
   }
 
-  func set(title: String, subTitle: String) {
-    self.textLabel?.text = title
-    self.detailTextLabel?.text = subTitle
+  func set(date: String, count: String, name: String) {
+    self.playDate.text = date
+    self.playCount.text = count
+    self.playerName.text = name
+  }
+
+  // MARK: Layout
+
+  private func layout() {
+    self.contentView.addSubview(self.playCount)
+    self.contentView.addSubview(self.playDate)
+    self.contentView.addSubview(self.playerName)
+
+    self.playerName.snp.makeConstraints {
+      $0.bottom.equalTo(self.contentView.snp.centerY).offset(-5)
+      $0.leading.equalToSuperview().inset(20)
+    }
+    self.playDate.snp.makeConstraints {
+      $0.top.equalTo(self.contentView.snp.centerY).offset(5)
+      $0.leading.equalToSuperview().inset(20)
+    }
+    self.playCount.snp.makeConstraints {
+      $0.centerY.equalToSuperview()
+      $0.trailing.equalToSuperview().inset(10)
+    }
   }
 }
+

--- a/NumberGame/Sources/Features/UpAndDown/UpAndDownGameViewController.swift
+++ b/NumberGame/Sources/Features/UpAndDown/UpAndDownGameViewController.swift
@@ -358,13 +358,9 @@ final class UpAndDownGameViewController: UIViewController {
 
   private func savePlayerLog(inputCount: Int) {
     self.dismiss(animated: true) {
-      let alert = UIAlertController(title: "플레이어의 입력을 입력하세요.", message: nil, preferredStyle: .alert)
-      alert.addTextField(configurationHandler: nil)
-      alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in
+      self.inputTextAlert(title: "플레이어의 이름을 입력하세요.") { alert in
         self.saveScoreToCoreData(inputCount: inputCount, name: alert.textFields?[0].text ?? "")
-      })
-
-      self.present(alert, animated: true)
+      }
     }
   }
 

--- a/NumberGame/Sources/Features/UpAndDown/UpAndDownGameViewController.swift
+++ b/NumberGame/Sources/Features/UpAndDown/UpAndDownGameViewController.swift
@@ -214,6 +214,7 @@ final class UpAndDownGameViewController: UIViewController {
   private func resetGame() {
     self.gameState = .playing
     self.answer = Int.random(in: 0...100)
+    print(answer)
     self.lastInputNumber = nil
     self.inputCount = 0
 
@@ -261,7 +262,7 @@ final class UpAndDownGameViewController: UIViewController {
     self.inputNumberStateLabel.text = "💯"
     self.inputCountLabel.text = "\(self.inputCount)번 만에 성공!"
 
-    self.saveScoreToCoreData(inputCount: self.inputCount)
+    self.savePlayerLog(inputCount: self.inputCount)
 
     self.button.setTitle("다시 시작", for: .normal)
   }
@@ -325,11 +326,12 @@ final class UpAndDownGameViewController: UIViewController {
     return dateFormatter.string(from: Date())
   }
 
-  private func saveScoreToCoreData(inputCount: Int) {
+  private func saveScoreToCoreData(inputCount: Int, name: String) {
     let context = self.context
     guard let scoreObject = NSEntityDescription.insertNewObject(forEntityName: Entity.score, into: context) as? ScoreMO else { return }
     scoreObject.date = self.changeDateToString()
     scoreObject.inputCount = Int64(inputCount)
+    scoreObject.playerName = name
     self.saveLogsToCoreData(ScoreObject: scoreObject)
 
     do {
@@ -351,6 +353,18 @@ final class UpAndDownGameViewController: UIViewController {
     let context = self.context
     for row in self.latelyResultLogsList {
       self.addLogToScoreObject(result: row, context: context ,ScoreObject: ScoreObject)
+    }
+  }
+
+  private func savePlayerLog(inputCount: Int) {
+    self.dismiss(animated: true) {
+      let alert = UIAlertController(title: "플레이어의 입력을 입력하세요.", message: nil, preferredStyle: .alert)
+      alert.addTextField(configurationHandler: nil)
+      alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in
+        self.saveScoreToCoreData(inputCount: inputCount, name: alert.textFields?[0].text ?? "")
+      })
+
+      self.present(alert, animated: true)
     }
   }
 

--- a/NumberGame/Sources/Utilities/CoreData/CoreDataService.swift
+++ b/NumberGame/Sources/Utilities/CoreData/CoreDataService.swift
@@ -11,6 +11,7 @@ import CoreData
 protocol CoreDataServiceProtocol: class {
   func fetch<T>(_:NSFetchRequest<T>) -> [T]
   func delete(_ objectID: NSManagedObjectID) -> Bool
+  func edit(_ objectID: NSManagedObjectID, name: String) -> Bool
   var context: NSManagedObjectContext? { get }
 }
 
@@ -58,6 +59,21 @@ class CoreDataService: CoreDataServiceProtocol {
     }
     let object = context.object(with: objectID)
     context.delete(object)
+
+    do {
+      try context.save()
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  func edit(_ objectID: NSManagedObjectID, name: String) -> Bool {
+    guard let context = self.context else {
+      return false
+    }
+    let object = context.object(with: objectID) as? ScoreMO
+    object?.playerName = name
 
     do {
       try context.save()

--- a/NumberGame/Sources/Utilities/Extensions.swift
+++ b/NumberGame/Sources/Utilities/Extensions.swift
@@ -1,8 +1,0 @@
-//
-//  Extensions.swift
-//  NumberGame
-//
-//  Created by 윤중현 on 2020/12/22.
-//
-
-import SnapKit

--- a/NumberGame/Sources/Utilities/UIViewController/UIViewController+Alert.swift
+++ b/NumberGame/Sources/Utilities/UIViewController/UIViewController+Alert.swift
@@ -1,0 +1,40 @@
+//
+//  UIViewController+Alert.swift
+//  NumberGame
+//
+//  Created by sangho Cho on 2021/04/07.
+//
+
+import Foundation
+import UIKit
+
+extension UIViewController {
+  func inputTextAlert(title: String, message: String? = nil, isCancel: Bool = false, completion: @escaping (UIAlertController) -> Void) {
+    let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+
+    alert.addTextField(configurationHandler: nil)
+
+    alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in
+      if let inputtedText = alert.textFields?[0].text, inputtedText.isEmpty {
+        self.dismiss(animated: true) {
+          let caution = UIAlertController(title: "이름을 입력해주세요.", message: nil, preferredStyle: .alert)
+          caution.addAction(UIAlertAction(title: "확인", style: .default) { _ in
+            self.dismiss(animated: true) {
+              self.present(alert, animated: true)
+            }
+          })
+
+          self.present(caution, animated: true)
+        }
+      } else {
+        completion(alert)
+      }
+    })
+
+    if isCancel {
+      alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+    }
+
+    self.present(alert, animated: true)
+  }
+}


### PR DESCRIPTION
# 배경

- #12 

# 작업 내용

- 정답을 입력하여 게임 플레이가 종료되었을 시, 플레이어의 이름을 입력할 수 있는 Alert을 노출하여 플레이어의 이름을 입력 받을 수 있도록 구현하였습니다.
- 입력한 플레이어의 이름은 Score View에서 셀의 좌측 스와이프를 통해 수정할 수 있도록 구현하였습니다.

# 리뷰 노트
- CoreDataProtocol에 Edit 메소드를 새로 추가하여, 저장된 데이터를 수정할 수 있는 메소드를 추가하였습니다.
- 이름 입력 및 변경 시 노출되는 Alert은 UIViewController에 Extension으로 추가하여 구현하였습니다.
- Score View Cell에 이름 Label이 추가됨에 따라 Cell의 높이를 조정하였습니다.


# 스크린샷
![ezgif com-gif-maker](https://user-images.githubusercontent.com/59811450/113748055-ff317880-9742-11eb-8340-7448622b6283.gif)



